### PR TITLE
feat ensured that appropriate rbacs are set to allow the ingressclass…

### DIFF
--- a/addons/nginx-ingress/google-cloud/rbac/cluster-role.yaml
+++ b/addons/nginx-ingress/google-cloud/rbac/cluster-role.yaml
@@ -59,4 +59,11 @@ rules:
       - get
       - list
       - watch
-
+  - apiGroups: 
+      - discovery.k8s.io
+    resources:
+      - "endpointslices"
+    verbs: 
+      - get
+      - list
+      - watch


### PR DESCRIPTION
… on gcp

High level description of the change.
fixes ingress permissions error;

 k8s.io/client-go@v0.25.3/tools/cache/reflector.go:169: Failed to watch *v1.EndpointSlice: failed to list *v1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:ingress:default" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope 

## Testing

Describe your work to validate the change works.

rel: issue number (if applicable)
